### PR TITLE
remove template info and upate the links

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@
 [![Python](https://img.shields.io/badge/python-3.10%20%7C%203.11%20%7C%203.12%20%7C%203.13-blue)](https://www.python.org/downloads/)
 [![Pixi Badge](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/prefix-dev/pixi/main/assets/badge/v0.json)](https://pixi.sh)
 
+Colcon runner is a minimal CLI wrapper for [colcon](https://colcon.readthedocs.io/en/released/) that provides concise and flexible commands for common build, test, and clean tasks in ROS workspaces. It supports [colcon defaults](https://colcon.readthedocs.io/en/released/user/configuration.html#colcon-defaults-yaml) for consistent configuration.
+
 ```
 CR(1)                         User Commands                        CR(1)
 

--- a/README.md
+++ b/README.md
@@ -1,27 +1,13 @@
-# colcon_runner
-A template repo for python projects that is set up using [pixi](https://pixi.sh). 
-
-This has basic setup for
-
-* pylint
-* ruff
-* black
-* pytest
-* git-lfs
-* basic github actions ci
-* pulling updates from this template
-* codecov
-* pypi upload
-* dependabot
+# colcon-runner
 
 ## Continuous Integration Status
 
-[![Ci](https://github.com/blooop/colcon_runner/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/blooop/colcon_runner/actions/workflows/ci.yml?query=branch%3Amain)
-[![Codecov](https://codecov.io/gh/blooop/colcon_runner/branch/main/graph/badge.svg?token=Y212GW1PG6)](https://codecov.io/gh/blooop/colcon_runner)
-[![GitHub issues](https://img.shields.io/github/issues/blooop/colcon_runner.svg)](https://GitHub.com/blooop/colcon_runner/issues/)
-[![GitHub pull-requests merged](https://badgen.net/github/merged-prs/blooop/colcon_runner)](https://github.com/blooop/colcon_runner/pulls?q=is%3Amerged)
-[![GitHub release](https://img.shields.io/github/release/blooop/colcon_runner.svg)](https://GitHub.com/blooop/colcon_runner/releases/)
-[![License](https://img.shields.io/github/license/blooop/colcon_runner)](https://opensource.org/license/mit/)
+[![Ci](https://github.com/blooop/colcon-runner/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/blooop/colcon-runner/actions/workflows/ci.yml?query=branch%3Amain)
+[![Codecov](https://codecov.io/gh/blooop/colcon-runner/branch/main/graph/badge.svg?token=Y212GW1PG6)](https://codecov.io/gh/blooop/colcon-runner)
+[![GitHub issues](https://img.shields.io/github/issues/blooop/colcon-runner.svg)](https://GitHub.com/blooop/colcon-runner/issues/)
+[![GitHub pull-requests merged](https://badgen.net/github/merged-prs/blooop/colcon-runner)](https://github.com/blooop/colcon-runner/pulls?q=is%3Amerged)
+[![GitHub release](https://img.shields.io/github/release/blooop/colcon-runner.svg)](https://GitHub.com/blooop/colcon-runner/releases/)
+[![License](https://img.shields.io/github/license/blooop/colcon-runner)](https://opensource.org/license/mit/)
 [![Python](https://img.shields.io/badge/python-3.10%20%7C%203.11%20%7C%203.12%20%7C%203.13-blue)](https://www.python.org/downloads/)
 [![Pixi Badge](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/prefix-dev/pixi/main/assets/badge/v0.json)](https://pixi.sh)
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,14 @@
 
 Colcon runner is a minimal CLI wrapper for [colcon](https://colcon.readthedocs.io/en/released/) that provides concise and flexible commands for common build, test, and clean tasks in ROS workspaces. It supports [colcon defaults](https://colcon.readthedocs.io/en/released/user/configuration.html#colcon-defaults-yaml) for consistent configuration.
 
+## Installation
+
+You can install colcon-runner using pip:
+
+```bash
+pip install colcon-runner
+```
+
 ```
 CR(1)                         User Commands                        CR(1)
 

--- a/pixi.lock
+++ b/pixi.lock
@@ -380,8 +380,8 @@ packages:
   requires_python: '>=3.8'
 - pypi: .
   name: colcon-runner
-  version: 0.2.3
-  sha256: a9e36186dcfec46d1d0b94e2d94d273753d240172c9e2730e86af2f0ae3df1ac
+  version: 0.2.4
+  sha256: 678519f6ab51cfefe23226dc3f71ccaa8119870d03da5f2ff0b899ac38e937dc
   requires_dist:
   - pylint>=3.2.5,<=3.3.7 ; extra == 'test'
   - pytest-cov>=4.1,<=6.1.1 ; extra == 'test'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "colcon_runner"
-version = "0.2.3"
+version = "0.2.4"
 authors = [{ name = "Austin Gregg-Smith", email = "blooop@gmail.com" }]
 description = "A python package template"
 readme = "README.md"


### PR DESCRIPTION
## Summary by Sourcery

Remove template placeholder content from README, correct repository name in badge links, and bump package version to 0.2.4

Documentation:
- Remove project template description and tool list from README
- Update CI and status badge URLs to use the hyphenated repository name

Chores:
- Bump project version from 0.2.3 to 0.2.4
- Regenerate pixi.lock file