### PR TITLE
Clear underlay env vars for colcon clean operations

### DIFF
--- a/colcon_runner/colcon_runner.py
+++ b/colcon_runner/colcon_runner.py
@@ -553,6 +553,10 @@ def _run_tool(tool: str, args: List[str], extra_opts: List[str]) -> None:
     if tool == "rosdep":
         env = os.environ.copy()
         env["PYTHONWARNINGS"] = "ignore::DeprecationWarning"
+    elif safe_args and safe_args[0] == "clean":
+        env = os.environ.copy()
+        env.pop("AMENT_PREFIX_PATH", None)
+        env.pop("CMAKE_PREFIX_PATH", None)
 
     # Use subprocess.run with shell=False for safety
     ret = subprocess.run(cmd, check=False, env=env).returncode

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "colcon-runner"
-version = "0.12.2"
+version = "0.12.3"
 authors = [{ name = "Austin Gregg-Smith", email = "blooop@gmail.com" }]
 description = "A concise CLI wrapper for colcon build/test/clean workflows."
 readme = "README.md"

--- a/test/test_basic.py
+++ b/test/test_basic.py
@@ -398,6 +398,7 @@ class CleanEnvTests(unittest.TestCase):
                 {
                     "AMENT_PREFIX_PATH": "/some/underlay/install/pkg",
                     "CMAKE_PREFIX_PATH": "/some/underlay/install/pkg",
+                    "SOME_OTHER_VAR": "keep_me",
                 },
             ):
                 colcon_runner.main(["co", "test_pkg"])
@@ -409,6 +410,7 @@ class CleanEnvTests(unittest.TestCase):
             self.assertIsNotNone(env, "subprocess.run should receive an env dict for clean")
             self.assertNotIn("AMENT_PREFIX_PATH", env)
             self.assertNotIn("CMAKE_PREFIX_PATH", env)
+            self.assertEqual(env.get("SOME_OTHER_VAR"), "keep_me")
 
     def test_build_does_not_clear_underlay_env_vars(self):
         """Build commands should NOT modify the environment."""

--- a/test/test_basic.py
+++ b/test/test_basic.py
@@ -378,6 +378,58 @@ class IntegrationTests(unittest.TestCase):
             m_sp.run.assert_not_called()
 
 
+class CleanEnvTests(unittest.TestCase):
+    """Test that clean commands clear underlay env vars."""
+
+    def setUp(self):
+        self.workspace_patch = mock.patch.object(
+            colcon_runner, "_find_workspace_root", return_value="/test/workspace"
+        )
+        self.workspace_patch.start()
+        self.addCleanup(self.workspace_patch.stop)
+
+    def test_clean_clears_underlay_env_vars(self):
+        """subprocess.run should receive env without AMENT_PREFIX_PATH and CMAKE_PREFIX_PATH."""
+        with mock.patch.object(colcon_runner, "subprocess") as m_sp:
+            m_sp.run.return_value.returncode = 0
+
+            with mock.patch.dict(
+                os.environ,
+                {
+                    "AMENT_PREFIX_PATH": "/some/underlay/install/pkg",
+                    "CMAKE_PREFIX_PATH": "/some/underlay/install/pkg",
+                },
+            ):
+                colcon_runner.main(["co", "test_pkg"])
+
+            # subprocess.run should have been called with an env kwarg
+            m_sp.run.assert_called_once()
+            call_kwargs = m_sp.run.call_args
+            env = call_kwargs.kwargs.get("env") or call_kwargs[1].get("env")
+            self.assertIsNotNone(env, "subprocess.run should receive an env dict for clean")
+            self.assertNotIn("AMENT_PREFIX_PATH", env)
+            self.assertNotIn("CMAKE_PREFIX_PATH", env)
+
+    def test_build_does_not_clear_underlay_env_vars(self):
+        """Build commands should NOT modify the environment."""
+        with mock.patch.object(colcon_runner, "subprocess") as m_sp:
+            m_sp.run.return_value.returncode = 0
+
+            with mock.patch.dict(
+                os.environ,
+                {
+                    "AMENT_PREFIX_PATH": "/some/underlay/install/pkg",
+                    "CMAKE_PREFIX_PATH": "/some/underlay/install/pkg",
+                },
+            ):
+                colcon_runner.main(["ba"])
+
+            m_sp.run.assert_called_once()
+            call_kwargs = m_sp.run.call_args
+            env = call_kwargs.kwargs.get("env") or call_kwargs[1].get("env")
+            self.assertIsNone(env, "build should not pass a custom env")
+
+
 class UpdateCacheTests(unittest.TestCase):
     # pylint: disable=protected-access
     def setUp(self):


### PR DESCRIPTION
## Summary

- Clear `AMENT_PREFIX_PATH` and `CMAKE_PREFIX_PATH` from the subprocess environment when running `colcon clean`, preventing "ignoring unknown package" warnings from underlay workspace discovery
- Build/test operations are unaffected — underlay warnings from `colcon-override-check` remain intentional
- Bump version to 0.12.3

## Test plan

- [x] New `CleanEnvTests` verify `subprocess.run` receives env without underlay vars for clean commands
- [x] New test verifies build commands do NOT modify the environment
- [x] All 103 existing tests pass
- [x] Linting passes (ruff, ty, pylint all clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Clear underlay-related environment variables when running colcon clean commands to avoid unintended underlay workspace discovery, while leaving build/test behavior unchanged, and bump the package version.

Bug Fixes:
- Prevent colcon clean subprocesses from inheriting AMENT_PREFIX_PATH and CMAKE_PREFIX_PATH, eliminating spurious warnings from underlay workspaces.

Build:
- Bump package version from 0.12.2 to 0.12.3.

Tests:
- Add tests verifying clean commands pass a sanitized environment without underlay vars and that build commands do not alter the environment.