### PR TITLE
Filter non-existent paths from env vars for all colcon commands

### DIFF
--- a/colcon_runner/colcon_runner.py
+++ b/colcon_runner/colcon_runner.py
@@ -541,12 +541,12 @@ def _handle_rosdep_update(extra_opts: List[str]) -> None:
 
 
 def _filter_existing_paths(path_string: str) -> str:
-    """Filter a colon-separated path string to only include paths that exist."""
+    """Filter a path-separated string to only include paths that exist."""
     if not path_string:
         return ""
-    paths = path_string.split(":")
+    paths = path_string.split(os.pathsep)
     existing = [p for p in paths if p and os.path.exists(p)]
-    return ":".join(existing)
+    return os.pathsep.join(existing)
 
 
 def _prepare_colcon_env() -> dict:

--- a/colcon_runner/colcon_runner.py
+++ b/colcon_runner/colcon_runner.py
@@ -540,6 +540,30 @@ def _handle_rosdep_update(extra_opts: List[str]) -> None:
     _mark_updated()
 
 
+def _filter_existing_paths(path_string: str) -> str:
+    """Filter a colon-separated path string to only include paths that exist."""
+    if not path_string:
+        return ""
+    paths = path_string.split(":")
+    existing = [p for p in paths if p and os.path.exists(p)]
+    return ":".join(existing)
+
+
+def _prepare_colcon_env() -> dict:
+    """Prepare environment for colcon commands, filtering out non-existent paths."""
+    env = os.environ.copy()
+    # Filter out non-existent paths from ROS/colcon path variables
+    # This prevents warnings about stale underlay paths after workspace cleaning
+    for var in ("AMENT_PREFIX_PATH", "CMAKE_PREFIX_PATH"):
+        if var in env:
+            filtered = _filter_existing_paths(env[var])
+            if filtered:
+                env[var] = filtered
+            else:
+                del env[var]
+    return env
+
+
 def _run_tool(tool: str, args: List[str], extra_opts: List[str]) -> None:
     """Run a tool (colcon or rosdep) with the given arguments."""
     # Defensive: ensure all args are strings and not user-controlled shell input
@@ -553,10 +577,8 @@ def _run_tool(tool: str, args: List[str], extra_opts: List[str]) -> None:
     if tool == "rosdep":
         env = os.environ.copy()
         env["PYTHONWARNINGS"] = "ignore::DeprecationWarning"
-    elif safe_args and safe_args[0] == "clean":
-        env = os.environ.copy()
-        env.pop("AMENT_PREFIX_PATH", None)
-        env.pop("CMAKE_PREFIX_PATH", None)
+    elif tool == "colcon":
+        env = _prepare_colcon_env()
 
     # Use subprocess.run with shell=False for safety
     ret = subprocess.run(cmd, check=False, env=env).returncode

--- a/pixi.lock
+++ b/pixi.lock
@@ -1285,8 +1285,8 @@ packages:
   requires_python: '>=3.6'
 - pypi: ./
   name: colcon-runner
-  version: 0.12.2
-  sha256: af65a84477aab4ec16ad7b57f6a309047c79b8334293b4347b55c0067d966629
+  version: 0.12.4
+  sha256: 030005db8263c35ded8cfad099f4fa3a9cb0d1430c15205b6519abcde61ad204
   requires_dist:
   - pylint>=3.2.5,<=4.0.4 ; extra == 'test'
   - pytest-cov>=4.1,<=7.0.0 ; extra == 'test'
@@ -2457,9 +2457,9 @@ packages:
   requires_dist:
   - attrs>=18.0.0
   - six>=1.12.0
-  - scandir>=1.9.0 ; python_full_version < '3.5'
-  - pathlib2>=2.3.3 ; python_full_version < '3.4'
   - pathspec>=0.5.9
+  - pathlib2>=2.3.3 ; python_full_version < '3.4'
+  - scandir>=1.9.0 ; python_full_version < '3.5'
 - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-79.0.1-pyhff2d567_0.conda
   sha256: 5ebc4bb71fbdc8048b08848519150c8d44b8eb18445711d3258c9d402ba87a2c
   md5: fa6669cc21abd4b7b6c5393b7bc71914

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "colcon-runner"
-version = "0.12.3"
+version = "0.12.4"
 authors = [{ name = "Austin Gregg-Smith", email = "blooop@gmail.com" }]
 description = "A concise CLI wrapper for colcon build/test/clean workflows."
 readme = "README.md"


### PR DESCRIPTION
## Summary
- Instead of only clearing `AMENT_PREFIX_PATH` and `CMAKE_PREFIX_PATH` for clean operations, now filter out non-existent paths for all colcon commands
- This fixes warnings during `cr cb` where the build step still had stale underlay paths after clean
- Legitimate underlay paths (that exist) are preserved
- Bump version to 0.12.4

## Test plan
- [x] Unit tests for `_filter_existing_paths()` helper
- [x] Integration tests verify existing paths preserved, non-existent paths removed
- [x] All 111 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Filter non-existent underlay paths from environment variables for all colcon invocations and add coverage for the new behavior.

New Features:
- Introduce a helper to sanitize colon-separated path environment variables by removing non-existent paths before running colcon commands.

Bug Fixes:
- Prevent colcon runs from using stale underlay paths in AMENT_PREFIX_PATH and CMAKE_PREFIX_PATH, eliminating related warnings after workspace cleaning.

Enhancements:
- Unify environment preparation for colcon commands via a dedicated helper used by the tool runner.
- Expand and rename tests to cover environment filtering behavior and the new path filtering helper.

Build:
- Bump colcon-runner package version to 0.12.4.

Tests:
- Add unit tests for the path filtering helper and integration-style tests verifying environment variables are correctly filtered or removed for colcon commands.