### PR TITLE
Bump version to 0.12.5 and update CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 ## colcon_runner
 
+## [0.12.5] - 2026-02-13
+
+### Changed
+- Updated CHANGELOG with missing entries for 0.12.2–0.12.4
+
+## [0.12.4] - 2026-02-12
+
+### Changed
+- Filter non-existent paths from `AMENT_PREFIX_PATH` and `CMAKE_PREFIX_PATH` for all colcon commands (build, test, clean)
+
+## [0.12.3] - 2026-02-10
+
+### Fixed
+- Clear stale underlay env vars (`AMENT_PREFIX_PATH`, `CMAKE_PREFIX_PATH`) for colcon clean operations
+
+## [0.12.2] - 2026-02-08
+
+### Fixed
+- Shell integration now uses `--install-base` to resolve the correct install path
+
 ## [0.12.0] - 2026-02-08
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "colcon-runner"
-version = "0.12.4"
+version = "0.12.5"
 authors = [{ name = "Austin Gregg-Smith", email = "blooop@gmail.com" }]
 description = "A concise CLI wrapper for colcon build/test/clean workflows."
 readme = "README.md"


### PR DESCRIPTION
## Summary
- Bump version to 0.12.5
- Add missing CHANGELOG entries for 0.12.2, 0.12.3, and 0.12.4 so the auto-publish action (`parse-changelog: true`) generates accurate release notes

## Context
The CHANGELOG hadn't been updated since 0.12.0, so releases 0.12.2–0.12.4 all got the same stale release notes on GitHub.

## Test plan
- [ ] Verify CHANGELOG entries are accurate
- [ ] Merge triggers auto-publish with correct 0.12.5 release notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Bump the package version to 0.12.5 and document recent releases in the changelog so release notes are accurate.

Build:
- Update project version metadata from 0.12.4 to 0.12.5 in pyproject configuration.

Documentation:
- Add changelog entries for versions 0.12.2, 0.12.3, 0.12.4, and 0.12.5, including notes on path filtering, env var cleanup, and shell integration behavior.